### PR TITLE
Switch from using matrix-transform to physical-layout in dtsi

### DIFF
--- a/config/boards/shields/corne/corne.dtsi
+++ b/config/boards/shields/corne/corne.dtsi
@@ -1,9 +1,14 @@
 #include <dt-bindings/zmk/matrix_transform.h>
+#include <layouts/foostan/corne/6column.dtsi>
+
+&foostan_corne_6col_layout {
+    transform = <&default_transform>;
+};
 
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,physical-layout = &foostan_corne_6col_layout;
     };
 
     default_transform: keymap_transform_0 {


### PR DESCRIPTION
This fixes incompatibility with ZMK Studio snippet (not enabling the ZMK Studio RPC support).